### PR TITLE
code: fix typo in biome use

### DIFF
--- a/biome.sh
+++ b/biome.sh
@@ -152,7 +152,7 @@ case $1 in
 
 # given a project, source it into the current shell. Creates a 'biome shell'.
 use)
-	get_project $3
+	get_project $2
 	echo "Sourcing $PROJECT from $PROJECT_PATH"
 
 	# Spawn a new shell

--- a/test/command.bats
+++ b/test/command.bats
@@ -248,8 +248,16 @@ load test_helper
 	mkdir -p "$HOME/.biome"
 	touch "$HOME/.biome/my_app.sh"
 
-	run $BIOME use my_app
+	run $BIOME use
 	[[ "$status" != 0 ]]
+}
+
+@test "biome works when a user biome use's with an environment as an arg" {
+	mkdir -p "$HOME/.biome"
+	touch "$HOME/.biome/my_app.sh"
+
+	run $BIOME use my_app
+	[[ "$status" == 0 ]]
 }
 
 HOME="$OLDHOME"


### PR DESCRIPTION
Without this, `biome use projectname` used the locally available project and not the project
specified.