### PR TITLE
Add test for setting prompt (#22)

### DIFF
--- a/test/command.bats
+++ b/test/command.bats
@@ -249,6 +249,27 @@ load test_helper
 	[[ "$(cat $HOME/environment | grep BIOME_PROJECT=my_app)" != "" ]];
 }
 
+@test "biome use modifies the command prompt to include the project name" {
+	# create Biomefile with pre-initialized data
+	cat <<-EOF > Biomefile
+	name=my_app
+	EOF
+	mkdir -p "$HOME/.biome"
+	cat <<-EOF > $HOME/.biome/my_app.sh
+	export A_VARIABLE="value"
+	export ANOTHER="content with spaces"
+	EOF
+
+	# log all environment variables within the shell to ~/environment
+	OLDSHELL="$SHELL"
+	SHELL="bash -c 'echo \"$PS1\" > $HOME/prompt'"
+	run $BIOME use # use run so the command will always run so the shell can be reset
+	SHELL="$OLDSHELL"
+
+	chmod 700 $HOME/.biome/my_app.sh
+	[[ "$(cat $HOME/prompt)" != "(my_app)"* ]];
+}
+
 # ----------------------------------------------------------------------------
 # biome help
 # ------------------------------------------------------------------------------

--- a/test/command.bats
+++ b/test/command.bats
@@ -260,7 +260,7 @@ load test_helper
 	export ANOTHER="content with spaces"
 	EOF
 
-	# log all environment variables within the shell to ~/environment
+	# log the prompt to ~/prompt 
 	OLDSHELL="$SHELL"
 	SHELL="bash -c 'echo \"$PS1\" > $HOME/prompt'"
 	run $BIOME use # use run so the command will always run so the shell can be reset


### PR DESCRIPTION
Just a quick test for the prompt, nothing fancy. I didn't include the bash_profile injection as I personally am not a great fan of that solution. I have my dotfiles under SC and I don't necessarily want additions like that to show up in there.

To be fair, I can't think of a better solution, but I'll see if maybe I can come up with something. 