### PR TITLE
Quote a few file redirects so environment names can have spaces

### DIFF
--- a/biome.sh
+++ b/biome.sh
@@ -85,7 +85,7 @@ function get_variable {
 }
 
 function make_template_project {
-	cat <<-EOF > ~/.biome/$PROJECT.sh
+	cat <<-EOF > "$HOME/.biome/$PROJECT.sh"
 	# A file that contains environment variables for a project
 	# Activate me with biome use $PROJECT
 	# add variables like export FOO="bar"
@@ -107,7 +107,7 @@ function fetch_var_values {
 
 				# also, get whether it's been set already.
 				if [[ -f "$PROJECT_PATH" ]]; then
-					VARIABLE_ALREADY_SET=$(cat $PROJECT_PATH | grep "^export $VARIABLE_NAME")
+					VARIABLE_ALREADY_SET=$(cat "$PROJECT_PATH" | grep "^export $VARIABLE_NAME")
 				else
 					VARIABLE_ALREADY_SET=""
 				fi
@@ -171,7 +171,7 @@ use)
 
 	# Spawn a new shell
 	set_meta_vars
-	bash -c "$(cat $PROJECT_PATH) && $SHELL -l"
+	bash -c "$(cat \"$PROJECT_PATH\") && $SHELL -l"
 	unset_meta_vars
 	;;
 

--- a/biome.sh
+++ b/biome.sh
@@ -171,7 +171,7 @@ use)
 
 	# Spawn a new shell
 	set_meta_vars
-	bash -c "$(cat \"$PROJECT_PATH\") && $SHELL -l"
+	bash -c "$(cat $PROJECT_PATH) && $SHELL -l"
 	unset_meta_vars
 	;;
 

--- a/test/command.bats
+++ b/test/command.bats
@@ -381,4 +381,18 @@ load test_helper
 	[[ "$status" == 0 ]]
 }
 
+# ----------------------------------------------------------------------------
+# Biomefile envionment names with spaces
+# ----------------------------------------------------------------------------
+@test "biome should be able to handle spaces in an environment name" {
+	echo "name=spaces for days" > ./Biomefile
+	mkdir -p "$HOME/.biome"
+	touch "$HOME/.biome/spaces for days.sh"
+
+	run $BIOME use "spaces for days"
+	[[ "$status" == 0 ]]
+	rm ./Biomefile
+}
+
+
 HOME="$OLDHOME"


### PR DESCRIPTION
Before, there was a lot of `echo "foo" > ~/.biome/$PROJECT.sh`. That fails when `$PROJECT` has spaces in it. I've replaced occurances of that with `echo "foo" > "$HOME/.biome/$PROJECT.sh"`, which seems to fix the spaces problem. Unfortunately, `~` is treated as a literal tilda in a string so we need to use `$HOME` which isn't as great imo.

Closes #35 