### PR TITLE
biome should ignore whitespace in biomefiles

### DIFF
--- a/biome.sh
+++ b/biome.sh
@@ -100,7 +100,7 @@ function fetch_var_values {
 
 	if [[ -f "$BIOMEFILE" ]]; then
 		while read -u 10 i; do
-			if [[ ! "$i" =~ ^# ]]; then # not a comment
+			if [[ ! "$i" =~ ^# ]] && [[ "$i" != "" ]]; then # not a comment or empty line
 				# get the variable name, its default value
 				VARIABLE_NAME=$(echo $i | sed 's/=.*//')
 				VARIABLE_DEFAULT_VALUE=$(echo $i | cut -f2- -d'=')

--- a/test/command.bats
+++ b/test/command.bats
@@ -86,6 +86,31 @@ load test_helper
 	EOF)
 }
 
+@test "biome will create the environment that's defined in the Biomefile, with whitespace" {
+	cat <<-EOF > Biomefile
+	name=my_app
+
+	FOO=hello
+
+	BAR=world
+	BAZ=
+	EOF
+
+	INPUT="$(cat <<-EOF
+	data
+
+	more data
+	EOF)"
+	echo "$INPUT" | $BIOME
+
+	chmod 700 "$HOME/.biome/my_app.sh"
+	$(cmp $HOME/.biome/my_app.sh <<-EOF
+		export FOO="data"
+		export BAR="world"
+		export FOO="more data"
+	EOF)
+}
+
 @test "biome will create the environment that's defined in the .Biomefile" {
 	cat <<-EOF > .Biomefile
 	name=my_app


### PR DESCRIPTION
For example, the whitespace shouldn't be counted as a variable:
```
name=foo

BAR=baz
```